### PR TITLE
Check double tap is same button

### DIFF
--- a/src/touch.cpp
+++ b/src/touch.cpp
@@ -620,7 +620,7 @@ void touch::doEvents() {
 			TouchEvent e = fireEvent(i, TE_RELEASE, fi.startPoint, prev, millis() - fi.startTime, fi.button, nullptr);
 			if (!doGestures(e)) {
 				if (e.duration < MAX_TAP) {
-					if (fi.tapPoint.valid()) {
+					if (fi.tapPoint.valid() && (fi.button->name == buttonFor(fi.tapPoint)->name)) {
 						// there was a stored tap, so it's a doubletap now
 						fireEvent(i, TE_DBLTAP, fi.startPoint, invalid, 0, fi.button, nullptr);
 						fi.tapPoint.set();


### PR DESCRIPTION
Hi Rop

I've noticed that a double tap, where the two taps are onto two different buttons, would still be registered as double tap and highlight the double tap indicator (blue) on the second button. I am not sure if that is intentional or even makes sense. I am also not sure whether this should be taken care of in the application code or in the touch library. I leave that to you. The pull-request is a possible fix for the touch library.

Thanks
Felix